### PR TITLE
Align introduction with FDEAA

### DIFF
--- a/input/FDEEE.xml
+++ b/input/FDEEE.xml
@@ -139,7 +139,7 @@
         based on implementation) unencrypted for such things as the Master Boot Record (MBR) or other
         AA/EE pre-authentication software. These FDE cPPs interpret the term “full drive encryption” 
         to allow FDE solutions to leave a portion of the storage device unencrypted so long as it 
-        does not contain protected data.<h:br/><h:br/>
+        does not contain plaintext user or plaintext authorization data.<h:br/><h:br/>
         
         Since the FDE cPPs support a variety of solutions, two cPPs describe the requirements for the
         FDE components shown in Figure 1.  


### PR DESCRIPTION
In https://github.com/commoncriteria/FDEAA/pull/12 the language was updated following the iTC discussion, that wasn't done yet in https://github.com/commoncriteria/FDEEE/pull/4 but https://github.com/commoncriteria/FDEEE/pull/4 got merged anyway. This commit fixes https://github.com/commoncriteria/FDEEE/pull/4 to align with https://github.com/commoncriteria/FDEAA/pull/12.