### PR TITLE
Remove choose-one-of for FPT_PWR_EXT.1

### DIFF
--- a/input/FDEEE.xml
+++ b/input/FDEEE.xml
@@ -4775,7 +4775,7 @@
           <dependencies>No dependencies</dependencies>
           <f-element id="fpt-pwr-ext-1-1">
             <title>
-              The TSF shall define the following compliant power saving states: <selectables choose-one-of="yes">
+              The TSF shall define the following compliant power saving states: <selectables>
                 <selectable>S3</selectable>
                 <selectable>S4</selectable>
                 <selectable>G2(S5)</selectable>


### PR DESCRIPTION
This is to align with FDEAA. Also the previous version of the cPP used "choose _at least_ one of" which does imply that multiple selections are allowed. Changing it to "choose one of" in the new version implies only one may be chosen.